### PR TITLE
Add Pretalx support

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -226,9 +226,16 @@ conference:
         # The duration in seconds added to the talk `duration` to account for postroll material
         # such as sponsor segments. If this is built into the table already then set this to zero.
         schedulePostBufferSeconds: 30
+    # Config options for the pretalx.org backend which is accessed using their API
+    pretalx:
+      # Address of the instance
+      instanceDomain: ""
+      # Access token for the API
+      # See https://docs.pretalx.org/en/latest/api/fundamentals.html#obtaining-an-api-token on how to get a token
+      apiToken: ""
 
   # Various prefixes used by the bot when parsing information.
-  prefixes:
+  prefixesprefixes:
     # The prefixes for the rooms listed in the pentabarf definition which
     # describe the rooms that are 'auditorium' rooms. The prefixes will be
     # trimmed when naming the room (unless an override is present).

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -121,15 +121,6 @@ conference:
   # The name of the conference.
   name: "FOSDEM 2021"
 
-  # The system used for the data
-  # Currently only "pentabarf" is supported
-  backendType: "pentabarf"
-
-  # The URL to the XML which is updated with conference information.
-  # This is read and parsed by the bot during the early stages of
-  # setting up the conference.
-  pentabarfDefinition: "https://fosdem.org/2021/schedule/xml"
-
   # The timezone that the the bot's database is operating off of.
   timezone: "Europe/Brussels"
 
@@ -144,87 +135,97 @@ conference:
   # Should never be less than 5 minutes.
   lookaheadMinutes: 5
 
-  # Connection information to get data about the conference during the conference.
-  # This can be readonly. Currently the bot only supports postgresql.
-  database:
-    host: "localhost"
-    port: 5432
-    username: "db_username"
-    password: "db_password"
-    database: "your_db"
-    sslmode: "require"
+  # Settings for the backends
+  backend:
+    # The system used for the data
+    # Currently only "pentabarf" is supported
+    type: "pentabarf"
+    # Settings that only affect pentabarf setups
+    pentabarf:
+      # The URL to the XML which is updated with conference information.
+      # This is read and parsed by the bot during the early stages of
+      # setting up the conference.
+      definition: "https://fosdem.org/2021/schedule/xml"
 
-    # Tables specific for the pentabarf backend
-    pentabarfTables:
-      # The table/view for the bot to access for information about people involved in the conference.
-      # Must at least have the following columns:
-      #  event_id         - TEXT(like) - The penta ID for the talk (event) associated with
-      #                                  the person, if relevant. Null if a coordinator.
-      #  person_id        - TEXT(like) - The penta ID for the person.
-      #  event_role       - TEXT(like) - One of [speaker, coordinator, host]. See roles later on.
-      #  name             - TEXT(like) - The full name, or otherwise useful name, for the person.
-      #  email            - TEXT(like) - The preferred email address for the person.
-      #  matrix_id        - TEXT(like) - If known, the Matrix User ID for the person, otherwise null.
-      #  conference_room  - TEXT(like) - The relevant room. This should match the event_id or be
-      #                                  the room where coordinators are assigned.
-      #
-      # People may be assigned multiple roles with multiple rows.
-      #
-      # Roles:
-      #  speaker      - A speaker for event_id. This person will get moderator in their talk's
-      #                 room, and invited to the auditorium backstage room. They will be required
-      #                 to check in before their talk starts.
-      #
-      #  host         - Someone who is moderating the talk itself in collaboration with the speakers
-      #                 for the event_id. One host must check in before the talk starts, otherwise
-      #                 the issue will be raised to the management room and coordinators will be
-      #                 asked to take over. Hosts will get moderator in their talk's room, and be
-      #                 invited to the public auditorium room, backstage room, and talk room.
-      #
-      #  coordinator  - These are typically people responsible for scheduling the auditorium's
-      #                 talks. They'll get moderator in the auditorium room, backstage room, and all
-      #                 talk rooms for their auditorium, though will only be invited to the auditorium
-      #                 and backstage room (and the talk rooms on-demand if needed to fill in for a
-      #                 missing host).
-      #
-      # The bot will ignore unknown events, rooms, and roles.
-      #
-      # CAUTION: Although the bot uses parameterized queries, it is unable to use the table name as
-      # a parameter. As such, this particular config value is vulnerable to SQL injection. Seeing as
-      # how you (the bot's admin) are the one entering it: don't do that to yourself.
-      tblPeople: "view_matrix_bot_export_people"
+      # Connection information to get data about the conference during the conference.
+      # This can be readonly. Currently the bot only supports postgresql.
+      database:
+        host: "localhost"
+        port: 5432
+        username: "db_username"
+        password: "db_password"
+        database: "your_db"
+        sslmode: "require"
 
-      # The table/view for the bot to access for information about the conference schedule.
-      # Must at least have the following columns:
-      #  event_id            - TEXT(like) - The penta ID for the talk (event).
-      #  conference_room     - TEXT(like) - The relevant room. This should match the event_id.
-      #  start_datetime      - TIMESTAMP WITHOUT TIME ZONE - The start time of the talk. The timezone
-      #                        is determined by the bot using the timezone elsewhere in this config.
-      #  duration            - INTERVAL   - How long the talk is meant to last (start to end).
-      #  presentation_length - INTERVAL   - The portion of `duration` where the speaker is presenting.
-      #                                     The remainder is assumed to be Q&A.
-      #  prerecorded         - BOOLEAN    - True if the presentation is prerecorded. When false, the
-      #                                     bot will assume that presentation_length is zero and switch
-      #                                     directly into "hallway" mode at start_datetime.
-      #
-      # The bot will ignore unknown talks. Any if the start_datetime is NULL then the bot will ignore
-      # that record. If the INTERVAL fields are NULL, the bot will assume zero.
-      #
-      # Note: the bot is capable of running both tblSchedule and tblPeople off the same table/view.
-      # It will use DISTINCT where it needs to in order to get accurate information.
-      #
-      # CAUTION: Although the bot uses parameterized queries, it is unable to use the table name as
-      # a parameter. As such, this particular config value is vulnerable to SQL injection. Seeing as
-      # how you (the bot's admin) are the one entering it: don't do that to yourself.
-      tblSchedule: "view_matrix_bot_export_schedule"
+        # The table/view for the bot to access for information about people involved in the conference.
+        # Must at least have the following columns:
+        #  event_id         - TEXT(like) - The penta ID for the talk (event) associated with
+        #                                  the person, if relevant. Null if a coordinator.
+        #  person_id        - TEXT(like) - The penta ID for the person.
+        #  event_role       - TEXT(like) - One of [speaker, coordinator, host]. See roles later on.
+        #  name             - TEXT(like) - The full name, or otherwise useful name, for the person.
+        #  email            - TEXT(like) - The preferred email address for the person.
+        #  matrix_id        - TEXT(like) - If known, the Matrix User ID for the person, otherwise null.
+        #  conference_room  - TEXT(like) - The relevant room. This should match the event_id or be
+        #                                  the room where coordinators are assigned.
+        #
+        # People may be assigned multiple roles with multiple rows.
+        #
+        # Roles:
+        #  speaker      - A speaker for event_id. This person will get moderator in their talk's
+        #                 room, and invited to the auditorium backstage room. They will be required
+        #                 to check in before their talk starts.
+        #
+        #  host         - Someone who is moderating the talk itself in collaboration with the speakers
+        #                 for the event_id. One host must check in before the talk starts, otherwise
+        #                 the issue will be raised to the management room and coordinators will be
+        #                 asked to take over. Hosts will get moderator in their talk's room, and be
+        #                 invited to the public auditorium room, backstage room, and talk room.
+        #
+        #  coordinator  - These are typically people responsible for scheduling the auditorium's
+        #                 talks. They'll get moderator in the auditorium room, backstage room, and all
+        #                 talk rooms for their auditorium, though will only be invited to the auditorium
+        #                 and backstage room (and the talk rooms on-demand if needed to fill in for a
+        #                 missing host).
+        #
+        # The bot will ignore unknown events, rooms, and roles.
+        #
+        # CAUTION: Although the bot uses parameterized queries, it is unable to use the table name as
+        # a parameter. As such, this particular config value is vulnerable to SQL injection. Seeing as
+        # how you (the bot's admin) are the one entering it: don't do that to yourself.
+        tblPeople: "view_matrix_bot_export_people"
 
-    # The duration in seconds added to the `presentation_length` to account for preroll material
-    # such as sponsor segments. If this is built into the table already then set this to zero.
-    schedulePreBufferSeconds: 30
+        # The table/view for the bot to access for information about the conference schedule.
+        # Must at least have the following columns:
+        #  event_id            - TEXT(like) - The penta ID for the talk (event).
+        #  conference_room     - TEXT(like) - The relevant room. This should match the event_id.
+        #  start_datetime      - TIMESTAMP WITHOUT TIME ZONE - The start time of the talk. The timezone
+        #                        is determined by the bot using the timezone elsewhere in this config.
+        #  duration            - INTERVAL   - How long the talk is meant to last (start to end).
+        #  presentation_length - INTERVAL   - The portion of `duration` where the speaker is presenting.
+        #                                     The remainder is assumed to be Q&A.
+        #  prerecorded         - BOOLEAN    - True if the presentation is prerecorded. When false, the
+        #                                     bot will assume that presentation_length is zero and switch
+        #                                     directly into "hallway" mode at start_datetime.
+        #
+        # The bot will ignore unknown talks. Any if the start_datetime is NULL then the bot will ignore
+        # that record. If the INTERVAL fields are NULL, the bot will assume zero.
+        #
+        # Note: the bot is capable of running both tblSchedule and tblPeople off the same table/view.
+        # It will use DISTINCT where it needs to in order to get accurate information.
+        #
+        # CAUTION: Although the bot uses parameterized queries, it is unable to use the table name as
+        # a parameter. As such, this particular config value is vulnerable to SQL injection. Seeing as
+        # how you (the bot's admin) are the one entering it: don't do that to yourself.
+        tblSchedule: "view_matrix_bot_export_schedule"
 
-    # The duration in seconds added to the talk `duration` to account for postroll material
-    # such as sponsor segments. If this is built into the table already then set this to zero.
-    schedulePostBufferSeconds: 30
+        # The duration in seconds added to the `presentation_length` to account for preroll material
+        # such as sponsor segments. If this is built into the table already then set this to zero.
+        schedulePreBufferSeconds: 30
+
+        # The duration in seconds added to the talk `duration` to account for postroll material
+        # such as sponsor segments. If this is built into the table already then set this to zero.
+        schedulePostBufferSeconds: 30
 
   # Various prefixes used by the bot when parsing information.
   prefixes:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -235,7 +235,7 @@ conference:
       apiToken: ""
 
   # Various prefixes used by the bot when parsing information.
-  prefixesprefixes:
+  prefixes:
     # The prefixes for the rooms listed in the pentabarf definition which
     # describe the rooms that are 'auditorium' rooms. The prefixes will be
     # trimmed when naming the room (unless an override is present).

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -140,6 +140,15 @@ conference:
     # The system used for the data
     # Currently only "pentabarf" is supported
     type: "pentabarf"
+
+    # The duration in seconds added to the `presentation_length` to account for preroll material
+    # such as sponsor segments. If this is built into the table already then set this to zero.
+    schedulePreBufferSeconds: 30
+
+    # The duration in seconds added to the talk `duration` to account for postroll material
+    # such as sponsor segments. If this is built into the table already then set this to zero.
+    schedulePostBufferSeconds: 30
+
     # Settings that only affect pentabarf setups
     pentabarf:
       # The URL to the XML which is updated with conference information.
@@ -218,14 +227,6 @@ conference:
         # a parameter. As such, this particular config value is vulnerable to SQL injection. Seeing as
         # how you (the bot's admin) are the one entering it: don't do that to yourself.
         tblSchedule: "view_matrix_bot_export_schedule"
-
-        # The duration in seconds added to the `presentation_length` to account for preroll material
-        # such as sponsor segments. If this is built into the table already then set this to zero.
-        schedulePreBufferSeconds: 30
-
-        # The duration in seconds added to the talk `duration` to account for postroll material
-        # such as sponsor segments. If this is built into the table already then set this to zero.
-        schedulePostBufferSeconds: 30
     # Config options for the pretalx.org backend which is accessed using their API
     pretalx:
       # Address of the instance

--- a/docs/pretalx-getting-started.md
+++ b/docs/pretalx-getting-started.md
@@ -1,0 +1,11 @@
+# Pretalx
+
+The documentation for pretalx can be found at https://docs.pretalx.org
+
+## Requirements for the bot
+
+- You need API access with organiser privileges
+- You need a "What is your Matrix ID?" question (case sensitive) for speakers (TODO: Curl command for generating this)
+- You need a "Slug for the submission?" question (case sensitive) for talks/submissisons to be filled by coordinators (TODO: Curl command for generating this)
+- API must be reachable by the bot
+- You need to know the id of the event

--- a/docs/pretalx-getting-started.md
+++ b/docs/pretalx-getting-started.md
@@ -7,5 +7,6 @@ The documentation for pretalx can be found at https://docs.pretalx.org
 - You need API access with organiser privileges
 - You need a "What is your Matrix ID?" question (case sensitive) for speakers (TODO: Curl command for generating this)
 - You need a "Slug for the submission?" question (case sensitive) for talks/submissisons to be filled by coordinators (TODO: Curl command for generating this)
+- You need a "Duration of the video?" question (case sensitive) for talks/submissisons to be filled by coordinators (TODO: Curl command for generating this)
 - API must be reachable by the bot
 - You need to know the id of the event

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "matrix-bot-sdk": "^0.5.19",
     "matrix-org-irc": "^1.2.0",
     "matrix-widget-api": "^0.1.0-beta.18",
-    "node-fetch": "^3.2.0",
+    "node-fetch": "^2.6.1",
     "pg": "^8.7.1",
     "postcss": "^8.4.6",
     "postcss-preset-env": "^7.3.0",

--- a/src/commands/BuildCommand.ts
+++ b/src/commands/BuildCommand.ts
@@ -34,10 +34,10 @@ export class BuildCommand implements ICommand {
         await client.sendReadReceipt(roomId, event['event_id']);
 
         let inputData;
-        switch (config.conference.backendType) {
+        switch (config.conference.backend.type) {
             case "pentabarf": {
-                if (config.conference.pentabarfDefinition) {
-                    inputData = await fetch(config.conference.pentabarfDefinition).then(r => r.text());
+                if (config.conference.backend.pentabarf) {
+                    inputData = await fetch(config.conference.backend.pentabarf.definition).then(r => r.text());
                     break;
                 } else {
                     const message = "Your bot is not set up correctly. Please check your config!";

--- a/src/commands/BuildCommand.ts
+++ b/src/commands/BuildCommand.ts
@@ -23,7 +23,7 @@ import config from "../config";
 import { Conference } from "../Conference";
 import { logMessage } from "../LogProxy";
 import { editNotice } from "../utils";
-import { getConferenceParser } from "../parsers/AParser";
+import { getConferenceParser } from "../parsers/ConferenceParser";
 
 export class BuildCommand implements ICommand {
     public readonly prefixes = ["build", "b"];
@@ -33,29 +33,8 @@ export class BuildCommand implements ICommand {
 
         await client.sendReadReceipt(roomId, event['event_id']);
 
-        let inputData;
-        switch (config.conference.backend.type) {
-            case "pentabarf": {
-                if (config.conference.backend.pentabarf) {
-                    inputData = await fetch(config.conference.backend.pentabarf.definition).then(r => r.text());
-                    break;
-                } else {
-                    const message = "Your bot is not set up correctly. Please check your config!";
-                    const reply = RichReply.createFor(roomId, event, message, message);
-                    reply["msgtype"] = "m.notice";
-                    await client.sendMessage(roomId, reply);
-                    return;
-                }
-            }
-            default: {
-                const message = "Your bot is not set up correctly. Please check your config!";
-                const reply = RichReply.createFor(roomId, event, message, message);
-                reply["msgtype"] = "m.notice";
-                await client.sendMessage(roomId, reply);
-                return;
-            }
-        }
-        const parsed = getConferenceParser(inputData);
+
+        const parsed = await getConferenceParser();
 
         if (!conference.isCreated) {
             await conference.createDb(parsed.conference);

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,8 @@ interface IConfig {
         };
         backend: {
             type: AvailableBackends;
+            schedulePreBufferSeconds: number;
+            schedulePostBufferSeconds: number;
             pentabarf?: {
                 definition: string;
                 database: {
@@ -98,8 +100,6 @@ interface IConfig {
                     sslmode: string;
                     tblPeople: string;
                     tblSchedule: string;
-                    schedulePreBufferSeconds: number;
-                    schedulePostBufferSeconds: number;
                 };
             };
             pretalx?: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,6 +102,10 @@ interface IConfig {
                     schedulePostBufferSeconds: number;
                 };
             };
+            pretalx?: {
+                instanceDomain: string;
+                apiToken: string;
+            };
         };
     };
     ircBridge: IRCBridgeOpts;

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ import { IRCBridge, IRCBridgeOpts } from "./IRCBridge";
 import { Scheduler } from "./Scheduler";
 import { CheckInMap } from "./CheckInMap";
 
-export type AvailableBackends = "pentabarf";
+export type AvailableBackends = "pentabarf" | "pretalx";
 
 interface IConfig {
     homeserverUrl: string;
@@ -54,8 +54,6 @@ interface IConfig {
     conference: {
         id: string;
         name: string;
-        backendType: AvailableBackends;
-        pentabarfDefinition?: string;
         timezone: string;
         lookaheadMinutes: number;
         supportRooms: {
@@ -87,19 +85,23 @@ interface IConfig {
                 prefixes: string[];
             };
         };
-        database: {
-            host: string;
-            port: number;
-            username: string;
-            password: string;
-            database: string;
-            sslmode: string;
-            pentabarfTables?: {
-                tblPeople: string;
-                tblSchedule: string;
+        backend: {
+            type: AvailableBackends;
+            pentabarf?: {
+                definition: string;
+                database: {
+                    host: string;
+                    port: number;
+                    username: string;
+                    password: string;
+                    database: string;
+                    sslmode: string;
+                    tblPeople: string;
+                    tblSchedule: string;
+                    schedulePreBufferSeconds: number;
+                    schedulePostBufferSeconds: number;
+                };
             };
-            schedulePreBufferSeconds: number;
-            schedulePostBufferSeconds: number;
         };
     };
     ircBridge: IRCBridgeOpts;

--- a/src/db/PentaDb.ts
+++ b/src/db/PentaDb.ts
@@ -119,7 +119,7 @@ export class PentaDb implements DBBackend {
     }
 
     private postprocessDbTalk(talk: IRawDbTalk): IDbTalk {
-        const qaStartDatetime = talk.qa_start_datetime + config.conference.backend.pentabarf.database.schedulePreBufferSeconds * 1000;
+        const qaStartDatetime = talk.qa_start_datetime + config.conference.backend.schedulePreBufferSeconds * 1000;
         let livestreamStartDatetime: number;
         if (talk.prerecorded) {
             // For prerecorded talks, a preroll is shown, followed by the talk recording, then an
@@ -127,9 +127,9 @@ export class PentaDb implements DBBackend {
             livestreamStartDatetime = qaStartDatetime;
         } else {
             // For live talks, both the preroll and interroll are shown, followed by the live talk.
-            livestreamStartDatetime = talk.start_datetime + config.conference.backend.pentabarf.database.schedulePreBufferSeconds * 1000;
+            livestreamStartDatetime = talk.start_datetime + config.conference.backend.schedulePreBufferSeconds * 1000;
         }
-        const livestreamEndDatetime = talk.end_datetime - config.conference.backend.pentabarf.database.schedulePostBufferSeconds * 1000;
+        const livestreamEndDatetime = talk.end_datetime - config.conference.backend.schedulePostBufferSeconds * 1000;
 
         return {
             ...talk,

--- a/src/db/PretalxDb.ts
+++ b/src/db/PretalxDb.ts
@@ -1,0 +1,133 @@
+import { DateTime } from "luxon";
+import config, { AvailableBackends } from "../config";
+import { IPretalxTalksResp, IPretalxTalksResult } from "../parsers/PretalxParser";
+import { DBBackend } from "./backendDb";
+import { IDbPerson } from "./DbPerson";
+import { IDbTalk } from "./DbTalk";
+
+export class PretalxDb implements DBBackend {
+    public getSystemName(): AvailableBackends {
+        return "pretalx";
+    }
+    public async findPeopleWithId(personId: string): Promise<IDbPerson[]> {
+        const pentalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
+        return pentalxTalks.results
+            .filter(talk => talk.speakers.some(speaker => speaker.code === personId))
+            .map(talk => {
+                const speaker = talk.speakers.find(speaker => speaker.code === personId);
+                return {
+                    name: speaker.name,
+                    event_id: talk.code,
+                    person_id: speaker.code,
+                    event_role: undefined, // TODO figure this out
+                    email: speaker.email,
+                    matrix_id: talk.answers.find(answer => answer.question["en"] === "What is your Matrix ID?").answer,
+                    conference_room: talk.slot.room["en"],
+                    remark: "", // pretalx has no remarks it seems
+                } as IDbPerson;
+            });
+    }
+
+    public async findAllPeopleForAuditorium(auditoriumId: string): Promise<IDbPerson[]> {
+        const pentalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
+        return pentalxTalks.results
+            .filter(talk => talk.slot.room["en"] === auditoriumId && config.conference.prefixes.auditoriumRooms.some(prefix => talk.slot.room.startsWith(prefix)))
+            .map(talk => talk.speakers
+                .map(speaker => {
+                    return {
+                        name: speaker.name,
+                        event_id: talk.code,
+                        person_id: speaker.code,
+                        event_role: undefined, // TODO figure this out
+                        email: speaker.email,
+                        matrix_id: talk.answers.find(answer => answer.question["en"] === "What is your Matrix ID?").answer,
+                        conference_room: talk.slot.room["en"],
+                        remark: "", // pretalx has no remarks it seems
+                    } as IDbPerson;
+                })
+            ).flat();
+    }
+
+    public async findAllPeopleForTalk(talkId: string): Promise<IDbPerson[]> {
+        const pentalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
+        return pentalxTalks.results
+            .filter(talk => talk.code === talkId)
+            .map(talk => talk.speakers
+                .map(speaker => {
+                    return {
+                        name: speaker.name,
+                        event_id: talk.code,
+                        person_id: speaker.code,
+                        event_role: undefined, // TODO figure this out
+                        email: speaker.email,
+                        matrix_id: talk.answers.find(answer => answer.question["en"] === "What is your Matrix ID?").answer,
+                        conference_room: talk.slot.room["en"],
+                        remark: "", // pretalx has no remarks it seems
+                    } as IDbPerson;
+                })
+            ).flat();
+    }
+
+    // Not supported
+    public async findAllPeopleWithRemark(remark: string): Promise<IDbPerson[]> {
+        return [] as IDbPerson[];
+    }
+
+    public async getUpcomingTalkStarts(inNextMinutes: number, minBefore: number): Promise<IDbTalk[]> {
+        throw new Error("Method not implemented.");
+    }
+
+    public async getUpcomingQAStarts(inNextMinutes: number, minBefore: number): Promise<IDbTalk[]> {
+        throw new Error("Method not implemented.");
+    }
+
+    public async getUpcomingTalkEnds(inNextMinutes: number, minBefore: number): Promise<IDbTalk[]> {
+        throw new Error("Method not implemented.");
+    }
+
+    public async getTalk(talkId: string): Promise<IDbTalk> {
+        const pentalxTalk = await this.fetchAPI<IPretalxTalksResult>(`api/events/${config.conference.id}/talks/${talkId} `, undefined, undefined);
+        return this.postprocessTalk(pentalxTalk);
+    }
+
+    private async fetchAPI<T>(endpoint: string, method = "GET", body: string | undefined): Promise<T> {
+        const resp = await fetch(`${config.conference.backend.pretalx.instanceDomain}/${endpoint}`,
+            {
+                method: method,
+                body: body,
+                headers: {
+                    "Authorization": `Token ${config.conference.backend.pretalx.apiToken}`
+                }
+            }
+        );
+        const json = await resp.json();
+        return json as T;
+    }
+
+    private postprocessTalk(pentalxTalk: IPretalxTalksResult): IDbTalk {
+        const prerecorded = true;// TODO check if we have files and then use those?
+        const qaStartTime = 0 + config.conference.backend.schedulePreBufferSeconds * 1000; // TODO calculate
+        let livestreamStartDatetime: number;
+        if (prerecorded) {
+            // For prerecorded talks, a preroll is shown, followed by the talk recording, then an
+            // interroll, then live Q&A.
+            livestreamStartDatetime = qaStartTime;
+        } else {
+            // For live talks, both the preroll and interroll are shown, followed by the live talk.
+            livestreamStartDatetime = DateTime.fromISO(pentalxTalk.slot.start).toMillis() + config.conference.backend.schedulePreBufferSeconds * 1000;
+        }
+        const livestreamEndDatetime = DateTime.fromISO(pentalxTalk.slot.end).toMillis() - config.conference.backend.schedulePostBufferSeconds * 1000;
+        return {
+            event_id: pentalxTalk.code,
+            conference_room: pentalxTalk.slot.room["en"],
+            start_datetime: DateTime.fromISO(pentalxTalk.slot.start).toMillis(),
+            duration_seconds: pentalxTalk.duration * 60,
+            presentation_length_seconds: 0, // TODO this we cant seem to get from the API easily
+            end_datetime: DateTime.fromISO(pentalxTalk.slot.end).toMillis(),
+            qa_start_datetime: qaStartTime,
+            prerecorded: prerecorded,
+            livestream_start_datetime: livestreamStartDatetime,
+            livestream_end_datetime: livestreamEndDatetime
+        };
+    }
+}

--- a/src/db/PretalxDb.ts
+++ b/src/db/PretalxDb.ts
@@ -31,7 +31,7 @@ export class PretalxDb implements DBBackend {
     public async findAllPeopleForAuditorium(auditoriumId: string): Promise<IDbPerson[]> {
         const pentalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
         return pentalxTalks.results
-            .filter(talk => talk.slot.room["en"] === auditoriumId && config.conference.prefixes.auditoriumRooms.some(prefix => talk.slot.room.startsWith(prefix)))
+            .filter(talk => talk.slot.room["en"] === auditoriumId && config.conference.prefixes.auditoriumRooms.some(prefix => { return talk.slot.room["en"].startsWith(prefix); }))
             .map(talk => talk.speakers
                 .map(speaker => {
                     return {

--- a/src/db/PretalxDb.ts
+++ b/src/db/PretalxDb.ts
@@ -1,8 +1,8 @@
 import { DateTime } from "luxon";
 import config, { AvailableBackends } from "../config";
-import { IPretalxTalksResp, IPretalxTalksResult } from "../parsers/PretalxParser";
+import { IPretalxAnswersResp, IPretalxTalksResp, IPretalxTalksResult } from "../parsers/PretalxParser";
 import { DBBackend } from "./backendDb";
-import { IDbPerson } from "./DbPerson";
+import { IDbPerson, Role } from "./DbPerson";
 import { IDbTalk } from "./DbTalk";
 import fetch from "node-fetch";
 
@@ -11,8 +11,12 @@ export class PretalxDb implements DBBackend {
         return "pretalx";
     }
     public async findPeopleWithId(personId: string): Promise<IDbPerson[]> {
-        const pentalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
-        return pentalxTalks.results
+        const pretalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
+        const pretalxAnswers = await this.fetchAPI<IPretalxAnswersResp>(`api/events/${config.conference.id}/answers `, undefined, undefined);
+        const matrix_id_resps = pretalxAnswers.results.filter(answer => {
+            return answer.person && answer.question.question["en"] === "What is your Matrix ID?";
+        });
+        return pretalxTalks.results
             .filter(talk => talk.speakers.some(speaker => speaker.code === personId))
             .map(talk => {
                 const speaker = talk.speakers.find(speaker => speaker.code === personId);
@@ -20,9 +24,9 @@ export class PretalxDb implements DBBackend {
                     name: speaker.name,
                     event_id: talk.code,
                     person_id: speaker.code,
-                    event_role: undefined, // TODO figure this out
+                    event_role: Role.Speaker, // TODO figure this out
                     email: speaker.email,
-                    matrix_id: talk.answers.find(answer => answer.question.question["en"] === "What is your Matrix ID?").answer,
+                    matrix_id: matrix_id_resps.find(answer => answer.person === speaker.code).answer,
                     conference_room: talk.slot.room["en"],
                     remark: "", // pretalx has no remarks it seems
                 } as IDbPerson;
@@ -30,8 +34,12 @@ export class PretalxDb implements DBBackend {
     }
 
     public async findAllPeopleForAuditorium(auditoriumId: string): Promise<IDbPerson[]> {
-        const pentalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
-        return pentalxTalks.results
+        const pretalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
+        const pretalxAnswers = await this.fetchAPI<IPretalxAnswersResp>(`api/events/${config.conference.id}/answers `, undefined, undefined);
+        const matrix_id_resps = pretalxAnswers.results.filter(answer => {
+            return answer.person && answer.question.question["en"] === "What is your Matrix ID?";
+        });
+        return pretalxTalks.results
             .filter(talk => talk.slot.room["en"] === auditoriumId && config.conference.prefixes.auditoriumRooms.some(prefix => { return talk.slot.room["en"].startsWith(prefix); }))
             .flatMap(talk => talk.speakers
                 .map(speaker => {
@@ -39,9 +47,9 @@ export class PretalxDb implements DBBackend {
                         name: speaker.name,
                         event_id: talk.code,
                         person_id: speaker.code,
-                        event_role: undefined, // TODO figure this out
+                        event_role: Role.Speaker, // TODO figure this out
                         email: speaker.email,
-                        matrix_id: talk.answers.find(answer => answer.question.question["en"] === "What is your Matrix ID?").answer,
+                        matrix_id: matrix_id_resps.find(answer => answer.person === speaker.code).answer,
                         conference_room: talk.slot.room["en"],
                         remark: "", // pretalx has no remarks it seems
                     } as IDbPerson;
@@ -50,8 +58,12 @@ export class PretalxDb implements DBBackend {
     }
 
     public async findAllPeopleForTalk(talkId: string): Promise<IDbPerson[]> {
-        const pentalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
-        return pentalxTalks.results
+        const pretalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
+        const pretalxAnswers = await this.fetchAPI<IPretalxAnswersResp>(`api/events/${config.conference.id}/answers `, undefined, undefined);
+        const matrix_id_resps = pretalxAnswers.results.filter(answer => {
+            return answer.person && answer.question.question["en"] === "What is your Matrix ID?";
+        });
+        return pretalxTalks.results
             .filter(talk => talk.code === talkId)
             .flatMap(talk => talk.speakers
                 .map(speaker => {
@@ -59,9 +71,9 @@ export class PretalxDb implements DBBackend {
                         name: speaker.name,
                         event_id: talk.code,
                         person_id: speaker.code,
-                        event_role: undefined, // TODO figure this out
+                        event_role: Role.Speaker, // TODO figure this out
                         email: speaker.email,
-                        matrix_id: talk.answers.find(answer => answer.question.question["en"] === "What is your Matrix ID?").answer,
+                        matrix_id: matrix_id_resps.find(answer => answer.person === speaker.code).answer,
                         conference_room: talk.slot.room["en"],
                         remark: "", // pretalx has no remarks it seems
                     } as IDbPerson;
@@ -76,9 +88,9 @@ export class PretalxDb implements DBBackend {
 
     public async getUpcomingTalkStarts(inNextMinutes: number, minBefore: number): Promise<IDbTalk[]> {
         // where starttime is >= now - minBefore AND starttime <= now + inNextMinutes
-        const pentalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
+        const pretalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
         const now = DateTime.now();
-        return pentalxTalks.results.filter(talk => {
+        return pretalxTalks.results.filter(talk => {
             const startTime = DateTime.fromISO(talk.slot.start);
             return startTime >= now.minus({ minutes: minBefore }) && startTime <= now.plus({ minutes: inNextMinutes });
         }).map(talk => this.postprocessTalk(talk));
@@ -86,9 +98,9 @@ export class PretalxDb implements DBBackend {
 
     public async getUpcomingQAStarts(inNextMinutes: number, minBefore: number): Promise<IDbTalk[]> {
         // where (starttime + presentation_length) is >= now - minBefore AND (starttime + presentation_length) <= now + inNextMinutes
-        const pentalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
+        const pretalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
         const now = DateTime.now();
-        return pentalxTalks.results.filter(talk => {
+        return pretalxTalks.results.filter(talk => {
             const presentation_length = talk.answers.find(answer => answer.question.question["en"] === "Duration of the video?").answer as number;
             const startTime = DateTime.fromISO(talk.slot.start).plus({ minutes: presentation_length });
             return startTime >= now.minus({ minutes: minBefore }) && startTime <= now.plus({ minutes: inNextMinutes });
@@ -97,17 +109,17 @@ export class PretalxDb implements DBBackend {
 
     public async getUpcomingTalkEnds(inNextMinutes: number, minBefore: number): Promise<IDbTalk[]> {
         // where (starttime + duration) is >= now - minBefore AND (starttime + duration) <= now + inNextMinutes
-        const pentalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
+        const pretalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
         const now = DateTime.now();
-        return pentalxTalks.results.filter(talk => {
+        return pretalxTalks.results.filter(talk => {
             const startTime = DateTime.fromISO(talk.slot.start).plus({ minutes: talk.duration });
             return startTime >= now.minus({ minutes: minBefore }) && startTime <= now.plus({ minutes: inNextMinutes });
         }).map(talk => this.postprocessTalk(talk));
     }
 
     public async getTalk(talkId: string): Promise<IDbTalk> {
-        const pentalxTalk = await this.fetchAPI<IPretalxTalksResult>(`api/events/${config.conference.id}/talks/${talkId} `, undefined, undefined);
-        return this.postprocessTalk(pentalxTalk);
+        const pretalxTalk = await this.fetchAPI<IPretalxTalksResult>(`api/events/${config.conference.id}/talks/${talkId} `, undefined, undefined);
+        return this.postprocessTalk(pretalxTalk);
     }
 
     private async fetchAPI<T>(endpoint: string, method = "GET", body: string | undefined): Promise<T> {
@@ -124,11 +136,11 @@ export class PretalxDb implements DBBackend {
         return json as T;
     }
 
-    private postprocessTalk(pentalxTalk: IPretalxTalksResult): IDbTalk {
+    private postprocessTalk(pretalxTalk: IPretalxTalksResult): IDbTalk {
         const prerecorded = true;// TODO check if we have files and then use those?
         let livestreamStartDatetime: number;
-        const videoLength = pentalxTalk.answers.find(answer => answer.question.question["en"] === "Duration of the video?").answer as number;
-        const qaStartTimeRaw = DateTime.fromISO(pentalxTalk.slot.start).plus({ minutes: videoLength });
+        const videoLength = pretalxTalk.answers.find(answer => answer.question.question["en"] === "Duration of the video?").answer as number;
+        const qaStartTimeRaw = DateTime.fromISO(pretalxTalk.slot.start).plus({ minutes: videoLength });
         const qaStartTime = qaStartTimeRaw.plus({ seconds: config.conference.backend.schedulePreBufferSeconds * 1000 }).toMillis();
         if (prerecorded) {
             // For prerecorded talks, a preroll is shown, followed by the talk recording, then an
@@ -136,16 +148,16 @@ export class PretalxDb implements DBBackend {
             livestreamStartDatetime = qaStartTime;
         } else {
             // For live talks, both the preroll and interroll are shown, followed by the live talk.
-            livestreamStartDatetime = DateTime.fromISO(pentalxTalk.slot.start).toMillis() + config.conference.backend.schedulePreBufferSeconds * 1000;
+            livestreamStartDatetime = DateTime.fromISO(pretalxTalk.slot.start).toMillis() + config.conference.backend.schedulePreBufferSeconds * 1000;
         }
-        const livestreamEndDatetime = DateTime.fromISO(pentalxTalk.slot.end).toMillis() - config.conference.backend.schedulePostBufferSeconds * 1000;
+        const livestreamEndDatetime = DateTime.fromISO(pretalxTalk.slot.end).toMillis() - config.conference.backend.schedulePostBufferSeconds * 1000;
         return {
-            event_id: pentalxTalk.code,
-            conference_room: pentalxTalk.slot.room["en"],
-            start_datetime: DateTime.fromISO(pentalxTalk.slot.start).toMillis(),
-            duration_seconds: pentalxTalk.duration * 60,
+            event_id: pretalxTalk.code,
+            conference_room: pretalxTalk.slot.room["en"],
+            start_datetime: DateTime.fromISO(pretalxTalk.slot.start).toMillis(),
+            duration_seconds: pretalxTalk.duration * 60,
             presentation_length_seconds: 0, // TODO this we cant seem to get from the API easily
-            end_datetime: DateTime.fromISO(pentalxTalk.slot.end).toMillis(),
+            end_datetime: DateTime.fromISO(pretalxTalk.slot.end).toMillis(),
             qa_start_datetime: qaStartTime,
             prerecorded: prerecorded,
             livestream_start_datetime: livestreamStartDatetime,

--- a/src/db/backendDb.ts
+++ b/src/db/backendDb.ts
@@ -3,6 +3,7 @@ import config, { AvailableBackends } from "../config";
 import { IDbPerson } from "./DbPerson";
 import { IDbTalk } from "./DbTalk";
 import { PentaDb } from "./PentaDb";
+import { PretalxDb } from "./PretalxDb";
 
 export abstract class DBBackend {
     public abstract getSystemName(): AvailableBackends;
@@ -26,6 +27,8 @@ export const getBackendDB = (): DBBackend => {
         case "pentabarf": {
             return new PentaDb();
         }
+        case "pretalx":
+            return new PretalxDb();
         default: {
             throw new Error("Unsupported backend type set in the config");
         }

--- a/src/db/backendDb.ts
+++ b/src/db/backendDb.ts
@@ -22,7 +22,7 @@ export abstract class DBBackend {
 }
 
 export const getBackendDB = (): DBBackend => {
-    switch (config.conference.backendType) {
+    switch (config.conference.backend.type) {
         case "pentabarf": {
             return new PentaDb();
         }

--- a/src/models/InterestRoom.ts
+++ b/src/models/InterestRoom.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { MatrixClient } from "matrix-bot-sdk";
 import { Conference } from "../Conference";
 import { MatrixRoom } from "./MatrixRoom";
-import { deprefix } from "../parsers/PentabarfParser";
+import { deprefix } from "../parsers/ConferenceParser";
 import { PhysicalRoom } from "./PhysicalRoom";
 
 /**

--- a/src/parsers/AParser.ts
+++ b/src/parsers/AParser.ts
@@ -12,7 +12,7 @@ export abstract class ConferenceParser {
 }
 
 export const getConferenceParser = (input: string): ConferenceParser => {
-    switch (config.conference.backendType) {
+    switch (config.conference.backend.type) {
         case "pentabarf": {
             return new PentabarfParser(input);
         }

--- a/src/parsers/ConferenceParser.ts
+++ b/src/parsers/ConferenceParser.ts
@@ -1,6 +1,7 @@
 import config, { AvailableBackends } from "../config";
 import { IAuditorium, IConference, IInterestRoom, IPerson, ITalk } from "../models/schedule";
 import { PentabarfParser } from "./PentabarfParser";
+import PretalxParser from "./PretalxParser";
 
 export abstract class ConferenceParser {
     public abstract getSystemName(): AvailableBackends;
@@ -11,11 +12,14 @@ export abstract class ConferenceParser {
     public readonly interestRooms: IInterestRoom[];
 }
 
-export const getConferenceParser = (input: string): ConferenceParser => {
+export const getConferenceParser = async (): Promise<ConferenceParser> => {
     switch (config.conference.backend.type) {
         case "pentabarf": {
+            const input = await fetch(config.conference.backend.pentabarf.definition).then(r => r.text());
             return new PentabarfParser(input);
         }
+        case "pretalx":
+            return PretalxParser.createPretalxParser();
         default: {
             throw new Error("Unsupported backend type set in the config");
         }

--- a/src/parsers/ConferenceParser.ts
+++ b/src/parsers/ConferenceParser.ts
@@ -1,4 +1,5 @@
 import config, { AvailableBackends } from "../config";
+import { RoomKind } from "../models/room_kinds";
 import { IAuditorium, IConference, IInterestRoom, IPerson, ITalk } from "../models/schedule";
 import { PentabarfParser } from "./PentabarfParser";
 import PretalxParser from "./PretalxParser";
@@ -25,3 +26,19 @@ export const getConferenceParser = async (): Promise<ConferenceParser> => {
         }
     }
 };
+
+export function deprefix(id: string): { kind: RoomKind, name: string; } {
+    const override = config.conference.prefixes.nameOverrides[id];
+
+    const auditoriumPrefix = config.conference.prefixes.auditoriumRooms.find(p => id.startsWith(p));
+    if (auditoriumPrefix) {
+        return { kind: RoomKind.Auditorium, name: override || id.slice(auditoriumPrefix.length) };
+    }
+
+    const interestPrefix = config.conference.prefixes.interestRooms.find(p => id.startsWith(p));
+    if (interestPrefix) {
+        return { kind: RoomKind.SpecialInterest, name: override || id.slice(interestPrefix.length) };
+    }
+
+    return { kind: RoomKind.SpecialInterest, name: override || id };
+}

--- a/src/parsers/PentabarfParser.ts
+++ b/src/parsers/PentabarfParser.ts
@@ -16,8 +16,8 @@ limitations under the License.
 
 import { IAuditorium, IConference, IInterestRoom, IPerson, ITalk } from "../models/schedule";
 import { RoomKind } from "../models/room_kinds";
-import config, { AvailableBackends } from "../config";
-import { ConferenceParser } from './ConferenceParser';
+import { AvailableBackends } from "../config";
+import { ConferenceParser, deprefix } from './ConferenceParser';
 import { XMLParser } from "fast-xml-parser";
 import { DateTime } from "luxon";
 
@@ -91,22 +91,6 @@ function arrayLike<T>(val: T | T[]): T[] {
 function simpleTimeParse(str: string): { hours: number, minutes: number; } {
     const parts = str.split(':');
     return { hours: Number(parts[0]), minutes: Number(parts[1]) };
-}
-
-export function deprefix(id: string): { kind: RoomKind, name: string; } {
-    const override = config.conference.prefixes.nameOverrides[id];
-
-    const auditoriumPrefix = config.conference.prefixes.auditoriumRooms.find(p => id.startsWith(p));
-    if (auditoriumPrefix) {
-        return { kind: RoomKind.Auditorium, name: override || id.slice(auditoriumPrefix.length) };
-    }
-
-    const interestPrefix = config.conference.prefixes.interestRooms.find(p => id.startsWith(p));
-    if (interestPrefix) {
-        return { kind: RoomKind.SpecialInterest, name: override || id.slice(interestPrefix.length) };
-    }
-
-    return { kind: RoomKind.SpecialInterest, name: override || id };
 }
 
 export class PentabarfParser implements ConferenceParser {

--- a/src/parsers/PentabarfParser.ts
+++ b/src/parsers/PentabarfParser.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { IAuditorium, IConference, IInterestRoom, IPerson, ITalk } from "../models/schedule";
 import { RoomKind } from "../models/room_kinds";
 import config, { AvailableBackends } from "../config";
-import { ConferenceParser } from './AParser';
+import { ConferenceParser } from './ConferenceParser';
 import { XMLParser } from "fast-xml-parser";
 import { DateTime } from "luxon";
 

--- a/src/parsers/PentabarfParser.ts
+++ b/src/parsers/PentabarfParser.ts
@@ -109,7 +109,7 @@ export function deprefix(id: string): { kind: RoomKind, name: string; } {
     return { kind: RoomKind.SpecialInterest, name: override || id };
 }
 
-export class PentabarfParser extends ConferenceParser {
+export class PentabarfParser implements ConferenceParser {
     public readonly parsed: IPentabarfSchedule;
 
     public readonly conference: IConference;
@@ -119,7 +119,6 @@ export class PentabarfParser extends ConferenceParser {
     public readonly interestRooms: IInterestRoom[];
 
     constructor(rawXml: string) {
-        super();
         const parser = new XMLParser({
             attributesGroupName: "attr",
             textNodeName: "#text",

--- a/src/parsers/PretalxParser.ts
+++ b/src/parsers/PretalxParser.ts
@@ -33,7 +33,7 @@ export interface IPretalxTalksResult {
             target: string;
             options: any[];
         };
-        answer: string;
+        answer: string | number;
         answer_file?: string;
         submission: string;
         person?: any;
@@ -161,7 +161,7 @@ export default class PretalxParser implements ConferenceParser {
                 dateTs: DateTime.fromISO(talk.slot.start).toMillis(),
                 startTime: DateTime.fromISO(talk.slot.start).toMillis(),
                 endTime: DateTime.fromISO(talk.slot.end).toMillis(),
-                slug: talk.answers.find(answer => answer.question.question["en"] === "Slug for the submission?")?.answer,
+                slug: talk.answers.find(answer => answer.question.question["en"] === "Slug for the submission?")?.answer as string,
                 title: talk.title,
                 subtitle: talk.abstract,
                 track: talk.slot.room["en"],

--- a/src/parsers/PretalxParser.ts
+++ b/src/parsers/PretalxParser.ts
@@ -1,0 +1,217 @@
+import config, { AvailableBackends } from "../config";
+import { IConference, IAuditorium, ITalk, IPerson, IInterestRoom } from "../models/schedule";
+import { ConferenceParser } from "./ConferenceParser";
+import fetch from "node-fetch";
+import { DateTime } from "luxon";
+import { RoomKind } from "../models/room_kinds";
+
+interface IPretalxSpeaker {
+    name: string;
+    code: string;
+    bioagraphy: string;
+}
+
+interface IPretalxTalksResult {
+    code: string;
+    speakers: IPretalxSpeaker[],
+    title: string;
+    state: "submitted" | "accepted" | "rejected" | "confirmed";
+    abstract: string;
+    description: string;
+    duration: number;
+    do_not_record: boolean;
+    is_featured: boolean;
+    content_locale: string;
+    slot: {
+        start: string;
+        end: string;
+        room: string;
+    };
+    answers: {
+        id: number;
+        question: {
+            id: number;
+            question: { [language: string]: string; };
+            required: boolean;
+            target: string;
+            options: any[];
+        };
+        answer: string;
+        answer_file?: string;
+        submission: string;
+        person?: any;
+        options: any[];
+    }[];
+    notes: string;
+    internal_notes: string;
+    tags: string[];
+}
+
+interface IPretalxResp<T> {
+    count: number;
+    next?: string;
+    previous?: string;
+    results: T[];
+}
+
+interface IPretalxTalksResp extends IPretalxResp<IPretalxTalksResult> { }
+
+interface IPretalxEvent {
+    name: { [language: string]: string; };
+    slug: string;
+    timezone: string;
+    date_from: string;
+    date_to?: string;
+    is_public: boolean;
+    urls: {
+        base: string;
+        schedule: string;
+        login: string;
+        feed: string;
+    };
+}
+
+interface IPretalxRoomsResult {
+    id: number;
+    name: { [language: string]: string; };
+    description: { [language: string]: string; };
+    capacity: number;
+    position: number;
+    speaker_info: { [language: string]: string; };
+    availabilities: { start: string; end: string; }[];
+}
+
+interface IPretalxRoomsResp extends IPretalxResp<IPretalxRoomsResult> { }
+
+interface IPretalxSpreakersResult {
+    code: string;
+    name: string;
+    biography: string;
+    submissions: string[];
+    avatar: string;
+    availabilities: {
+        id: number;
+        start: string;
+        end: string;
+        allDay: boolean;
+    };
+}
+
+interface IPretalxSpreakersResp extends IPretalxResp<IPretalxSpreakersResult> { }
+
+export default class PretalxParser implements ConferenceParser {
+    public getSystemName(): AvailableBackends {
+        return "pretalx";
+    }
+
+    public conference: IConference;
+    public auditoriums: IAuditorium[];
+    public talks: ITalk[];
+    public speakers: IPerson[];
+    public interestRooms: IInterestRoom[];
+
+    private constructor(conference: IConference, auditoriums: IAuditorium[], talks: ITalk[], speakers: IPerson[], interestRooms: IInterestRoom[]) {
+        this.conference = conference;
+        this.auditoriums = auditoriums;
+        this.talks = talks;
+        this.speakers = speakers;
+        this.interestRooms = interestRooms;
+    }
+
+    // Pretalx calls the conference an event
+    // 
+    // auditoriums/interestRooms are called slot.room in a talk.
+    //
+    // Matrix ID is handled using a question
+    // Talk slug should be done using a question
+    //
+    // See docs for more
+    public static async createPretalxParser(): Promise<PretalxParser> {
+        const pretalxConference = await this.fetchAPI<IPretalxEvent>(`api/events/${config.conference.id}`, undefined, undefined);
+        const pretalxRooms = await this.fetchAPI<IPretalxRoomsResp>(`api/events/${config.conference.id}/rooms `, undefined, undefined);
+        const pretalxTalks = await this.fetchAPI<IPretalxTalksResp>(`api/events/${config.conference.id}/talks `, undefined, undefined);
+        const pretalxSpeakers = await this.fetchAPI<IPretalxSpreakersResp>(`api/events/${config.conference.id}/speakers `, undefined, undefined);
+        const auditoriums: IAuditorium[] = [];
+        const interestRooms: IInterestRoom[] = [];
+
+        for (const room of pretalxRooms.results) {
+            if (config.conference.prefixes.auditoriumRooms.some(prefix => room.name["en"].startsWith(prefix))) {
+                if (!auditoriums.some(r => r.id === room.id.toString())) {
+                    auditoriums.push({
+                        id: room.id.toString(),
+                        name: room.name["en"],
+                        kind: RoomKind.Auditorium,
+                        talksByDate: {},
+                    });
+                }
+            } else if (config.conference.prefixes.interestRooms.some(prefix => room.name["en"].startsWith(prefix))) {
+                if (!interestRooms.some(r => r.id === room.id.toString())) {
+                    interestRooms.push({
+                        id: room.id.toString(),
+                        name: room.name["en"],
+                        kind: RoomKind.SpecialInterest
+                    });
+                }
+            }
+        }
+
+        const talks = pretalxTalks.results.map(talk => {
+            const italk: ITalk = {
+                id: talk.code,
+                dateTs: DateTime.fromISO(talk.slot.start).toMillis(),
+                startTime: DateTime.fromISO(talk.slot.start).toMillis(),
+                endTime: DateTime.fromISO(talk.slot.end).toMillis(),
+                slug: talk.answers.find(answer => answer.question["en"] === "Slug for the submission?").answer,
+                title: talk.title,
+                subtitle: talk.abstract,
+                track: talk.slot.room,
+                speakers: talk.speakers.map(speaker => {
+                    return {
+                        id: speaker.code,
+                        name: speaker.name
+                    } as IPerson;
+                }),
+            };
+            const auditoriumroom = auditoriums.find(room => room.name === talk.slot.room);
+            if (auditoriumroom) {
+                if (auditoriumroom.talksByDate[DateTime.fromISO(talk.slot.start).toMillis()]) {
+                    auditoriumroom.talksByDate[DateTime.fromISO(talk.slot.start).toMillis()].push(italk);
+                } else {
+                    auditoriumroom.talksByDate[DateTime.fromISO(talk.slot.start).toMillis()];
+                    auditoriumroom.talksByDate[DateTime.fromISO(talk.slot.start).toMillis()] = [italk];
+                }
+            }
+            return italk;
+        });
+
+        const conference = {
+            title: pretalxConference.name["en"],
+            auditoriums: auditoriums,
+            interestRooms: interestRooms,
+        };
+
+        const speakers: IPerson[] = pretalxSpeakers.results.map(speaker => {
+            return {
+                id: speaker.code,
+                name: speaker.name
+            };
+        });
+
+
+        return new PretalxParser(conference, auditoriums, talks, speakers, interestRooms);
+    }
+
+    private static async fetchAPI<T>(endpoint: string, method = "GET", body: string | undefined): Promise<T> {
+        const resp = await fetch(`${config.conference.backend.pretalx.instanceDomain}/${endpoint}`,
+            {
+                method: method,
+                body: body,
+                headers: {
+                    "Authorization": `Token ${config.conference.backend.pretalx.apiToken}`
+                }
+            }
+        );
+        const json = await resp.json();
+        return json as T;
+    }
+}

--- a/src/parsers/PretalxParser.ts
+++ b/src/parsers/PretalxParser.ts
@@ -97,6 +97,15 @@ export interface IPretalxSpreakersResult {
 
 export interface IPretalxSpreakersResp extends IPretalxResp<IPretalxSpreakersResult> { }
 
+export interface IPretalxAnswersResult {
+    id: number;
+    answer: string | number;
+    question: { id: number; question: { [language: string]: string; }; };
+    person?: string;
+}
+
+export interface IPretalxAnswersResp extends IPretalxResp<IPretalxAnswersResult> { }
+
 export default class PretalxParser implements ConferenceParser {
     public getSystemName(): AvailableBackends {
         return "pretalx";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "emitDecoratorMetadata": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2015",
+    "target": "es2019",
     "noImplicitAny": false,
     "sourceMap": true,
     "outDir": "./lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,11 +1232,6 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-uri-to-buffer@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
-  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
-
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
@@ -1870,14 +1865,6 @@ faye-websocket@^0.11.3:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.4.tgz#e8c6567f80ad7fc22fd302e7dcb72bafde9c1717"
-  integrity sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==
-  dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
-
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
@@ -1944,13 +1931,6 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
-  dependencies:
-    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -2985,19 +2965,12 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
-node-fetch@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.0.tgz#59390db4e489184fa35d4b74caf5510e8dfbaf3b"
-  integrity sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==
+node-fetch@^2.6.1:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
+    whatwg-url "^5.0.0"
 
 node-forge@^1.2.0:
   version "1.2.1"
@@ -4494,6 +4467,11 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 ts-loader@^9.2.6:
   version "9.2.6"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.2.6.tgz#9937c4dd0a1e3dbbb5e433f8102a6601c6615d74"
@@ -4654,10 +4632,10 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-web-streams-polyfill@^3.0.3:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
-  integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
 webpack-cli@^4.9.2:
   version "4.9.2"
@@ -4780,6 +4758,14 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
This adds initial [pretalx](pretalx.org) support to the bot

For an upstream PR this change also would include the changes needed to make it have the generic interface

### Known missing/TODOs

- [x] getUpcomingTalkStarts
- [x] getUpcomingQAStarts
- [x] getUpcomingTalkEnds
- [ ] Paginate API
- [ ] Check if all timezones are set up correct
- [ ] Figure out event_role
- [x] Figure out presentation length
- [x] Figure out qaStartTime